### PR TITLE
Add historian character and dynamic character support

### DIFF
--- a/src/components/AdminArticleForm.tsx
+++ b/src/components/AdminArticleForm.tsx
@@ -12,20 +12,19 @@ export function AdminArticleForm() {
   const [content, setContent] = useState("");
   const { mutateAsync: publish } = useNostrPublish();
   const { toast } = useToast();
-  const { socialist, capitalist, summarize } = useGrokSummary();
+  const { historian, summarize } = useGrokSummary();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      await publish({
+      const event = await publish({
         kind: 30023,
-        content,
+        content: `Title: ${title}\n\n${content}`,
         tags: [
-          ["title", title],
           ["published_at", datetime || new Date().toISOString()],
         ],
       });
-      await summarize(content);
+      await summarize(content, event.id);
       toast({ title: "Article posted" });
       setTitle("");
       setDatetime("");
@@ -56,20 +55,10 @@ export function AdminArticleForm() {
         />
         <Button type="submit">Post Article</Button>
       </form>
-      {socialist && (
+      {historian && (
         <div className="space-y-2">
-          <p className="font-semibold">Socialist Summary</p>
-          <p className="text-sm text-gray-700 dark:text-gray-300">
-            {socialist}
-          </p>
-        </div>
-      )}
-      {communist && (
-        <div className="space-y-2">
-          <p className="font-semibold">Communist Summary</p>
-          <p className="text-sm text-gray-700 dark:text-gray-300">
-            {communist}
-          </p>
+          <p className="font-semibold">Historian Summary</p>
+          <p className="text-sm text-gray-700 dark:text-gray-300">{historian}</p>
         </div>
       )}
     </div>

--- a/src/components/AdminCharacterForm.tsx
+++ b/src/components/AdminCharacterForm.tsx
@@ -1,0 +1,35 @@
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useCharacters } from "@/hooks/useCharacters";
+
+export function AdminCharacterForm() {
+  const [name, setName] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const { addCharacter } = useCharacters();
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    await addCharacter.mutateAsync({ name, prompt });
+    setName("");
+    setPrompt("");
+  };
+
+  return (
+    <form onSubmit={handleSubmit} className="space-y-4">
+      <Input
+        placeholder="Character Name"
+        value={name}
+        onChange={(e) => setName(e.target.value)}
+      />
+      <Textarea
+        placeholder="Prompt"
+        className="h-20"
+        value={prompt}
+        onChange={(e) => setPrompt(e.target.value)}
+      />
+      <Button type="submit">Create Character</Button>
+    </form>
+  );
+}

--- a/src/components/AdminPostForm.tsx
+++ b/src/components/AdminPostForm.tsx
@@ -12,12 +12,12 @@ export function AdminPostForm() {
   const [content, setContent] = useState("");
   const { mutateAsync: publish } = useNostrPublish();
   const { toast } = useToast();
-  const { socialist, capitalist, summarize } = useGrokSummary();
+  const { historian, summarize } = useGrokSummary();
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const noteContent = `${title}\n\n${content}`;
+      const noteContent = `Title: ${title}\n\n${content}`;
       const event = await publish({
         kind: 1,
         content: noteContent,
@@ -55,20 +55,10 @@ export function AdminPostForm() {
         />
         <Button type="submit">Post Article</Button>
       </form>
-      {socialist && (
+      {historian && (
         <div className="space-y-2">
-          <p className="font-semibold">Socialist Summary</p>
-          <p className="text-sm text-gray-700 dark:text-gray-300">
-            {socialist}
-          </p>
-        </div>
-      )}
-      {capitalist && (
-        <div className="space-y-2">
-          <p className="font-semibold">Capitalist Summary</p>
-          <p className="text-sm text-gray-700 dark:text-gray-300">
-            {capitalist}
-          </p>
+          <p className="font-semibold">Historian Summary</p>
+          <p className="text-sm text-gray-700 dark:text-gray-300">{historian}</p>
         </div>
       )}
     </div>

--- a/src/components/NoteContent.tsx
+++ b/src/components/NoteContent.tsx
@@ -13,12 +13,22 @@ interface NoteContentProps {
 
 /** Parses content of text note events so that URLs and hashtags are linkified. */
 export function NoteContent({
-  event, 
-  className, 
-}: NoteContentProps) {  
+  event,
+  className,
+}: NoteContentProps) {
+  const lines = event.content.split("\n");
+  let header = "";
+  let text = event.content;
+  if (lines[0].startsWith("Title:")) {
+    header = lines[0].replace("Title:", "").trim();
+    text = lines.slice(1).join("\n");
+  } else if (lines[0].startsWith("Character:")) {
+    header = lines[0].replace("Character:", "").trim();
+    text = lines.slice(1).join("\n");
+  }
+
   // Process the content to render mentions, links, etc.
-  const content = useMemo(() => {
-    const text = event.content;
+  const body = useMemo(() => {
     
     // Regex to find URLs, Nostr references, and hashtags
     const regex = /(https?:\/\/[^\s]+)|nostr:(npub1|note1|nprofile1|nevent1)([023456789acdefghjklmnpqrstuvwxyz]+)|(#\w+)/g;
@@ -105,11 +115,21 @@ export function NoteContent({
     }
     
     return parts;
-  }, [event]);
+  }, [text]);
 
   return (
-    <div className={cn("whitespace-pre-wrap break-words", className)}>
-      {content.length > 0 ? content : event.content}
+    <div className={cn("whitespace-pre-wrap break-words space-y-1", className)}>
+      {header && (
+        <a
+          href={`https://primal.net/e/${event.id}`}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="font-semibold text-lg hover:underline block"
+        >
+          {header}
+        </a>
+      )}
+      <div>{body.length > 0 ? body : text}</div>
     </div>
   );
 }

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,6 +1,4 @@
 export const ADMIN_NPUB =
   "npub1ezfgxp8rynlln9ulkeeqpakxdhu9wa8amnl9dlnvm48axenpee6quu3mjy";
-export const SOCIALISM_NSEC =
+export const HISTORIAN_NSEC =
   "nsec1y3tt05l8g945akrr6rnmzsesja9yllry97ph5s303qpggvteyvgqyc0typ";
-export const CAPITALISM_NSEC =
-  "nsec1yu033d0rpdqdhwte8rz0s5gqqkanpnnt64e3qgps9345nj85z9ws8ty3lj";

--- a/src/hooks/useCharacters.ts
+++ b/src/hooks/useCharacters.ts
@@ -1,0 +1,39 @@
+import { collection, getDocs, addDoc } from "firebase/firestore";
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { generatePrivateKey, getPublicKey, nip19 } from "nostr-tools";
+import { db } from "@/lib/firebaseResources";
+
+export interface Character {
+  id?: string;
+  name: string;
+  prompt: string;
+  nsec: string;
+  npub: string;
+}
+
+const colRef = collection(db, "characters");
+
+export function useCharacters() {
+  const queryClient = useQueryClient();
+
+  const charactersQuery = useQuery({
+    queryKey: ["characters"],
+    queryFn: async () => {
+      const snap = await getDocs(colRef);
+      return snap.docs.map((d) => ({ id: d.id, ...(d.data() as Character) }));
+    },
+  });
+
+  const addCharacter = useMutation({
+    mutationFn: async ({ name, prompt }: { name: string; prompt: string }) => {
+      const sk = generatePrivateKey();
+      const pk = getPublicKey(sk);
+      const nsec = nip19.nsecEncode(sk);
+      const npub = nip19.npubEncode(pk);
+      await addDoc(colRef, { name, prompt, nsec, npub });
+    },
+    onSuccess: () => queryClient.invalidateQueries(["characters"]),
+  });
+
+  return { characters: charactersQuery.data ?? [], addCharacter };
+}

--- a/src/hooks/useGrokSummary.ts
+++ b/src/hooks/useGrokSummary.ts
@@ -1,7 +1,5 @@
 import { useState } from "react";
-import { nip19, getEventHash, getPublicKey } from "nostr-tools";
-import { SOCIALISM_NSEC, CAPITALISM_NSEC } from "@/constants";
-import { useNostrPublish } from "@/hooks/useNostrPublish";
+import { HISTORIAN_NSEC } from "@/constants";
 import { useNostrPublishWithKey } from "./useNostrPublishWithKey";
 import { model } from "@/lib/firebaseResources";
 
@@ -13,46 +11,37 @@ const callGrok = async (prompt: string) => {
 
 export function useGrokSummary() {
   const { mutateAsync: publishAnon } = useNostrPublishWithKey();
-  const [socialist, setSocialist] = useState("");
-  const [capitalist, setCapitalist] = useState("");
+  const [historian, setHistorian] = useState("");
 
   const publishEvent = async (
-    nsec: string, // you can drop this if publishEvent reads it from storage
+    nsec: string,
     summary: string,
     parentId: string
   ) => {
     await publishAnon({
-      nsec: nsec,
+      nsec,
       content: summary,
       tags: [["e", parentId]],
     });
   };
 
   const summarize = async (content: string, parentId: string) => {
-    const basePrompt = `Summarize the following text from a`;
-    const prompts = [
-      `${basePrompt} socialist perspective:\n\n${content}`,
-      `${basePrompt} capitalist perspective:\n\n${content}`,
-    ];
+    const prompt =
+      `Give information and educational background before discussing the current state of affairs. Additionally, offer frequent debates related to the matter and forms of propaganda that may be flourishing as a result of it. Make it expository and connect the dots for the audience to process further. Context:` +
+      "\n\n" +
+      content;
 
     // const controller = new AbortController();
     // const timeout = setTimeout(() => controller.abort(), 5000);
 
     try {
-      const [soc, cap] = await Promise.all(
-        prompts.map((p) =>
-          callGrok(
-            p
-            // ,
-            // controller.signal
-          )
-        )
+      const his = await callGrok(prompt);
+      setHistorian(his);
+      await publishEvent(
+        HISTORIAN_NSEC,
+        `Character: Historian\n\n${his}`,
+        parentId
       );
-      setSocialist(soc);
-      setCapitalist(cap);
-
-      await publishEvent(SOCIALISM_NSEC, soc, parentId);
-      await publishEvent(CAPITALISM_NSEC, cap, parentId);
     } catch (err) {
       console.error("Grok summary or publish failed:", err);
     } finally {
@@ -60,5 +49,5 @@ export function useGrokSummary() {
     }
   };
 
-  return { socialist, capitalist, summarize };
+  return { historian, summarize };
 }

--- a/src/lib/firebaseResources.ts
+++ b/src/lib/firebaseResources.ts
@@ -3,6 +3,7 @@ import { initializeApp } from "firebase/app";
 import { getAnalytics } from "firebase/analytics";
 import { getAI, getGenerativeModel, VertexAIBackend } from "firebase/ai";
 import { initializeAppCheck, ReCaptchaV3Provider } from "firebase/app-check";
+import { getFirestore } from "firebase/firestore";
 
 // TODO: Add SDKs for Firebase products that you want to use
 // https://firebase.google.com/docs/web/setup#available-libraries
@@ -33,5 +34,6 @@ const appCheck = initializeAppCheck(app, {
 
 const analytics = getAnalytics(app);
 const ai = getAI(app, { backend: new VertexAIBackend() });
+export const db = getFirestore(app);
 
 export const model = getGenerativeModel(ai, { model: "gemini-2.5-flash" });

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -2,6 +2,7 @@ import { useSeoMeta } from "@unhead/react";
 import { LoginArea } from "@/components/auth/LoginArea";
 import { useIsAdmin } from "@/hooks/useIsAdmin";
 import { AdminPostForm } from "@/components/AdminPostForm";
+import { AdminCharacterForm } from "@/components/AdminCharacterForm";
 import { useNutsack } from "@/hooks/useNutsack";
 import { Button } from "@/components/ui/button";
 import { PostFeed } from "@/components/PostFeed";
@@ -23,8 +24,9 @@ const Index = () => {
         <Button onClick={() => deposit(1)}>Deposit 1</Button>
       </div>
       {isAdmin && (
-        <div className="w-full max-w-xl">
+        <div className="w-full max-w-xl space-y-4">
           <AdminPostForm />
+          <AdminCharacterForm />
         </div>
       )}
       {!isAdmin && <Button onClick={() => zap(1)}>Zap Admin</Button>}


### PR DESCRIPTION
## Summary
- restrict summarization to a single historian character
- support creating additional characters in Firestore
- include admin form to create characters
- add Title/Character parsing in `NoteContent`
- include historian key constant and expose Firestore db

## Testing
- `npm run test` *(fails: npm cannot access network)*

------
https://chatgpt.com/codex/tasks/task_e_685a0e8fb8548326b381e460e3f332de