### PR TITLE
Improve newspaper look with PWA install modal

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,6 +12,7 @@ import { TooltipProvider } from "@/components/ui/tooltip";
 import { NostrLoginProvider } from '@nostrify/react/login';
 import { AppProvider } from '@/components/AppProvider';
 import { AppConfig } from '@/contexts/AppContext';
+import HeaderActions from '@/components/HeaderActions';
 import AppRouter from './AppRouter';
 
 const head = createHead({
@@ -51,6 +52,7 @@ export function App() {
                 <Toaster />
                 <Sonner />
                 <Suspense>
+                  <HeaderActions />
                   <AppRouter />
                 </Suspense>
               </TooltipProvider>

--- a/src/components/DownloadAppModal.tsx
+++ b/src/components/DownloadAppModal.tsx
@@ -1,0 +1,41 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
+import { Button } from '@/components/ui/button';
+import { MoreHorizontal, Share } from 'lucide-react';
+import type { FC } from 'react';
+
+interface DownloadAppModalProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+const DownloadAppModal: FC<DownloadAppModalProps> = ({ open, onOpenChange }) => (
+  <Dialog open={open} onOpenChange={onOpenChange}>
+    <DialogContent className="max-w-md">
+      <DialogHeader>
+        <DialogTitle>Install Character News</DialogTitle>
+        <DialogDescription>
+          Follow these steps to add the app to your home screen:
+        </DialogDescription>
+      </DialogHeader>
+      <ol className="list-decimal list-inside space-y-3 py-2 text-sm">
+        <li className="flex items-start gap-2">
+          <MoreHorizontal className="w-4 h-4 mt-1" />
+          <span>
+            Tap <strong>More</strong> then <strong>Share</strong>. This step is optional on some social media browsers.
+          </span>
+        </li>
+        <li className="flex items-start gap-2">
+          <Share className="w-4 h-4 mt-1" />
+          <span>
+            Choose <strong>Add to Home Screen</strong>.
+          </span>
+        </li>
+      </ol>
+      <div className="pt-2 text-right">
+        <Button variant="outline" onClick={() => onOpenChange(false)}>Close</Button>
+      </div>
+    </DialogContent>
+  </Dialog>
+);
+
+export default DownloadAppModal;

--- a/src/components/DownloadAppModal.tsx
+++ b/src/components/DownloadAppModal.tsx
@@ -1,14 +1,23 @@
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '@/components/ui/dialog';
-import { Button } from '@/components/ui/button';
-import { MoreHorizontal, Share } from 'lucide-react';
-import type { FC } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { MoreHorizontal, Share, SquarePlus } from "lucide-react";
+import type { FC } from "react";
 
 interface DownloadAppModalProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
 }
 
-const DownloadAppModal: FC<DownloadAppModalProps> = ({ open, onOpenChange }) => (
+const DownloadAppModal: FC<DownloadAppModalProps> = ({
+  open,
+  onOpenChange,
+}) => (
   <Dialog open={open} onOpenChange={onOpenChange}>
     <DialogContent className="max-w-md">
       <DialogHeader>
@@ -21,18 +30,26 @@ const DownloadAppModal: FC<DownloadAppModalProps> = ({ open, onOpenChange }) => 
         <li className="flex items-start gap-2">
           <MoreHorizontal className="w-4 h-4 mt-1" />
           <span>
-            Tap <strong>More</strong> then <strong>Share</strong>. This step is optional on some social media browsers.
+            Tap <strong>More</strong> to open the app in your browser if you're
+            accessing this through social media.
           </span>
         </li>
         <li className="flex items-start gap-2">
           <Share className="w-4 h-4 mt-1" />
+          Tap <strong>Share</strong> in your browser window.
+        </li>
+
+        <li className="flex items-start gap-2">
+          <SquarePlus className="w-4 h-4 mt-1" />
           <span>
             Choose <strong>Add to Home Screen</strong>.
           </span>
         </li>
       </ol>
       <div className="pt-2 text-right">
-        <Button variant="outline" onClick={() => onOpenChange(false)}>Close</Button>
+        <Button variant="outline" onClick={() => onOpenChange(false)}>
+          Close
+        </Button>
       </div>
     </DialogContent>
   </Dialog>

--- a/src/components/HeaderActions.tsx
+++ b/src/components/HeaderActions.tsx
@@ -1,0 +1,24 @@
+import { useState } from 'react';
+import { Download } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { cn } from '@/lib/utils';
+import { LoginArea } from '@/components/auth/LoginArea';
+import DownloadAppModal from './DownloadAppModal';
+
+interface HeaderActionsProps {
+  className?: string;
+}
+
+export default function HeaderActions({ className }: HeaderActionsProps) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div className={cn('fixed top-0 right-0 flex gap-2 p-2 z-50', className)}>
+      <LoginArea className="max-w-60" />
+      <Button size='icon' variant='ghost' onClick={() => setOpen(true)}>
+        <Download className='w-4 h-4' />
+      </Button>
+      <DownloadAppModal open={open} onOpenChange={setOpen} />
+    </div>
+  );
+}

--- a/src/components/HeaderActions.tsx
+++ b/src/components/HeaderActions.tsx
@@ -1,9 +1,9 @@
-import { useState } from 'react';
-import { Download } from 'lucide-react';
-import { Button } from '@/components/ui/button';
-import { cn } from '@/lib/utils';
-import { LoginArea } from '@/components/auth/LoginArea';
-import DownloadAppModal from './DownloadAppModal';
+import { useState } from "react";
+import { Download } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+import { LoginArea } from "@/components/auth/LoginArea";
+import DownloadAppModal from "./DownloadAppModal";
 
 interface HeaderActionsProps {
   className?: string;
@@ -13,11 +13,17 @@ export default function HeaderActions({ className }: HeaderActionsProps) {
   const [open, setOpen] = useState(false);
 
   return (
-    <div className={cn('fixed top-0 right-0 flex gap-2 p-2 z-50', className)}>
-      <LoginArea className="max-w-60" />
-      <Button size='icon' variant='ghost' onClick={() => setOpen(true)}>
-        <Download className='w-4 h-4' />
+    <div className={cn("fixed top-0 right-0 flex gap-2 p-5 z-50", className)}>
+      <Button
+        className="flex items-center gap-2 px-4 py-2  bg-primary text-primary-foreground w-full font-medium transition-all hover:bg-primary/90 animate-scale-in"
+        size="icon"
+        onClick={() => setOpen(true)}
+        style={{ backgroundColor: "#9e9e9e", color: "black" }}
+      >
+        <Download className="w-4 h-4" />
       </Button>
+      <LoginArea className="max-w-60" />
+
       <DownloadAppModal open={open} onOpenChange={setOpen} />
     </div>
   );

--- a/src/components/HeaderActions.tsx
+++ b/src/components/HeaderActions.tsx
@@ -18,7 +18,7 @@ export default function HeaderActions({ className }: HeaderActionsProps) {
         className="flex items-center gap-2 px-4 py-2  bg-primary text-primary-foreground w-full font-medium transition-all hover:bg-primary/90 animate-scale-in"
         size="icon"
         onClick={() => setOpen(true)}
-        style={{ backgroundColor: "#9e9e9e", color: "black" }}
+        style={{ backgroundColor: "#bdbdbd", color: "black" }}
       >
         <Download className="w-4 h-4" />
       </Button>

--- a/src/components/PostFeed.tsx
+++ b/src/components/PostFeed.tsx
@@ -58,8 +58,16 @@ function PostItem({ event }: PostItemProps) {
         <AccordionContent>
           <NoteContent event={event} />
           {replies.map((r, index) => (
-            <div key={r.id} className="pt-4 border-l pl-4">
-              <Accordion type="single" collapsible>
+            <div
+              key={r.id}
+              className="pt-4 border-l pl-4"
+              style={{ borderLeft: "1px solid #bfbfbf" }}
+            >
+              <Accordion
+                type="single"
+                collapsible
+                style={{ borderBottom: "1px solid #bfbfbf" }}
+              >
                 <AccordionItem value={r.id}>
                   <AccordionTrigger className="text-sm">
                     {parseHeader(r)}

--- a/src/components/auth/LoginArea.tsx
+++ b/src/components/auth/LoginArea.tsx
@@ -1,14 +1,14 @@
 // NOTE: This file is stable and usually should not be modified.
 // It is important that all functionality in this file is preserved, and should only be modified if explicitly requested.
 
-import { useState } from 'react';
-import { User } from 'lucide-react';
-import { Button } from '@/components/ui/button.tsx';
-import LoginDialog from './LoginDialog';
-import SignupDialog from './SignupDialog';
-import { useLoggedInAccounts } from '@/hooks/useLoggedInAccounts';
-import { AccountSwitcher } from './AccountSwitcher';
-import { cn } from '@/lib/utils';
+import { useState } from "react";
+import { User } from "lucide-react";
+import { Button } from "@/components/ui/button.tsx";
+import LoginDialog from "./LoginDialog";
+import SignupDialog from "./SignupDialog";
+import { useLoggedInAccounts } from "@/hooks/useLoggedInAccounts";
+import { AccountSwitcher } from "./AccountSwitcher";
+import { cn } from "@/lib/utils";
 
 export interface LoginAreaProps {
   className?: string;
@@ -31,16 +31,16 @@ export function LoginArea({ className }: LoginAreaProps) {
       ) : (
         <Button
           onClick={() => setLoginDialogOpen(true)}
-          className='flex items-center gap-2 px-4 py-2 rounded-full bg-primary text-primary-foreground w-full font-medium transition-all hover:bg-primary/90 animate-scale-in'
+          className="flex items-center gap-2 px-4 py-2  bg-primary text-primary-foreground w-full font-medium transition-all hover:bg-primary/90 animate-scale-in"
+          style={{ backgroundColor: "#9e9e9e", color: "black" }}
         >
-          <User className='w-4 h-4' />
-          <span className='truncate'>Log in</span>
+          <User className="w-4 h-4" />
         </Button>
       )}
 
       <LoginDialog
-        isOpen={loginDialogOpen} 
-        onClose={() => setLoginDialogOpen(false)} 
+        isOpen={loginDialogOpen}
+        onClose={() => setLoginDialogOpen(false)}
         onLogin={handleLogin}
         onSignup={() => setSignupDialogOpen(true)}
       />

--- a/src/components/auth/LoginArea.tsx
+++ b/src/components/auth/LoginArea.tsx
@@ -32,7 +32,7 @@ export function LoginArea({ className }: LoginAreaProps) {
         <Button
           onClick={() => setLoginDialogOpen(true)}
           className="flex items-center gap-2 px-4 py-2  bg-primary text-primary-foreground w-full font-medium transition-all hover:bg-primary/90 animate-scale-in"
-          style={{ backgroundColor: "#9e9e9e", color: "black" }}
+          style={{ backgroundColor: "#bdbdbd", color: "black" }}
         >
           <User className="w-4 h-4" />
         </Button>

--- a/src/index.css
+++ b/src/index.css
@@ -97,11 +97,11 @@
 
   body {
     @apply text-foreground;
-    background-color: hsl(var(--background));
-    background-image:
-      radial-gradient(circle at 0.5px 0.5px, rgba(0,0,0,0.05) 1px, transparent 0),
-      radial-gradient(circle at 2.5px 2.5px, rgba(0,0,0,0.04) 1px, transparent 0);
-    background-size: 4px 4px;
+    font-family: Georgia, 'Times New Roman', Times, serif;
+    background-color: #f7f7f7;
+    background-image: url("data:image/svg+xml;base64,PHN2ZyB4bWxucz0naHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmcnIHdpZHRoPScyMDAnIGhlaWdodD0nMjAwJz48ZmlsdGVyIGlkPSduJz48ZmVUdXJidWxlbmNlIHR5cGU9J2ZyYWN0YWxOb2lzZScgYmFzZUZyZXF1ZW5jeT0nMC44JyBudW1PY3RhdmVzPSc0JyAvPjwvZmlsdGVyPjxyZWN0IHdpZHRoPScyMDAnIGhlaWdodD0nMjAwJyBmaWx0ZXI9J3VybCglMjNuKScgb3BhY2l0eT0nMC4xNScvPjwvc3ZnPg==");
+    background-size: 200px 200px;
+    background-repeat: repeat;
   }
 
   a {

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -8,7 +8,7 @@ const About = () => {
   });
 
   return (
-    <div className="min-h-screen flex items-center justify-center p-6 bg-gray-100 dark:bg-gray-900">
+    <div className="min-h-screen flex items-center justify-center p-6">
       <div className="max-w-prose text-center space-y-4">
         <h1 className="text-2xl font-bold">About Character News</h1>
         <p className="text-gray-700 dark:text-gray-300 p-6">

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -33,7 +33,10 @@ const Index = () => {
         </div>
       )}
       {/* {!isAdmin && <Button onClick={() => zap(1)}>Zap Admin</Button>} */}
-      <div className="w-full max-w-xl">
+      <div
+        className="w-full max-w-xl"
+        style={{ borderBottom: "1px solid #bfbfbf" }}
+      >
         <PostFeed />
       </div>
 

--- a/src/pages/Index.tsx
+++ b/src/pages/Index.tsx
@@ -1,5 +1,4 @@
 import { useSeoMeta } from "@unhead/react";
-import { LoginArea } from "@/components/auth/LoginArea";
 import { useIsAdmin } from "@/hooks/useIsAdmin";
 import { AdminPostForm } from "@/components/AdminPostForm";
 import { AdminCharacterForm } from "@/components/AdminCharacterForm";
@@ -18,12 +17,11 @@ const Index = () => {
   const { balance, deposit, zap } = useNutsack();
 
   return (
-    <div className="min-h-screen flex flex-col items-center gap-6 p-6 bg-gray-100 dark:bg-gray-900">
+    <div className="min-h-screen flex flex-col items-center gap-6 p-6">
       <h1 className="text-2xl font-bold">Character News</h1>
       <Link to="/about" className="text-sm">
         About
       </Link>
-      <LoginArea className="max-w-60" />
       {/* <div className="text-center space-y-4">
         <p className="text-gray-800 dark:text-gray-200">Balance: {balance}</p>
         <Button onClick={() => deposit(1)}>Deposit 1</Button>

--- a/src/pages/NotFound.tsx
+++ b/src/pages/NotFound.tsx
@@ -18,7 +18,7 @@ const NotFound = () => {
   }, [location.pathname]);
 
   return (
-    <div className="min-h-screen flex items-center justify-center bg-gray-100 dark:bg-gray-900">
+    <div className="min-h-screen flex items-center justify-center">
       <div className="text-center">
         <h1 className="text-4xl font-bold mb-4 text-gray-900 dark:text-gray-100">404</h1>
         <p className="text-xl text-gray-600 dark:text-gray-400 mb-4">Oops! Page not found</p>


### PR DESCRIPTION
## Summary
- adjust global styles for a newspaper look
- remove page specific background colors
- add fixed login/download header actions
- include modal with instructions to install the PWA

## Testing
- `npm run test` *(fails: network access blocked)*

------
https://chatgpt.com/codex/tasks/task_e_685d977302688326a585c83a962357f6