### PR TITLE
Initialize wallet on user login

### DIFF
--- a/src/hooks/useNutsack.ts
+++ b/src/hooks/useNutsack.ts
@@ -1,7 +1,8 @@
-import { useCallback, useRef, useState } from "react";
+import { useCallback, useRef, useState, useEffect } from "react";
 import { useLocalStorage } from "./useLocalStorage";
 import NDK, { NDKZapper, NDKUser } from "@nostr-dev-kit/ndk";
 import { NDKCashuWallet } from "@nostr-dev-kit/ndk-wallet";
+import { useCurrentUser } from "./useCurrentUser";
 
 /**
  * Thin wrapper around the NDKCashuWallet API. The actual wallet
@@ -14,6 +15,7 @@ export function useNutsack() {
   const [invoice, setInvoice] = useState<string>("");
   const ndkRef = useRef<NDK>();
   const walletRef = useRef<NDKCashuWallet>();
+  const { user } = useCurrentUser();
 
   /**
    * Request an invoice from the wallet for the given amount. The returned
@@ -39,6 +41,12 @@ export function useNutsack() {
       });
     }
   }, [setBalance]);
+
+  useEffect(() => {
+    if (user) {
+      void init();
+    }
+  }, [user, init]);
 
   const deposit = useCallback(
     async (amount: number) => {


### PR DESCRIPTION
## Summary
- initialize the NDK wallet once a user logs in
- trigger init via effect so deposits work the first time

## Testing
- `npx -y @soapbox.pub/js-dev-mcp@latest run_script test` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68643b755e0883269b4d4058b3dedc1f