### PR TITLE
Fix nutsack signer

### DIFF
--- a/src/hooks/useNutsack.ts
+++ b/src/hooks/useNutsack.ts
@@ -1,6 +1,7 @@
 import { useCallback, useRef, useState, useEffect } from "react";
 import { useLocalStorage } from "./useLocalStorage";
-import NDK, { NDKZapper, NDKUser } from "@nostr-dev-kit/ndk";
+import NDK, { NDKZapper, NDKUser, NDKPrivateKeySigner } from "@nostr-dev-kit/ndk";
+import { nip19 } from "nostr-tools";
 import { NDKCashuWallet } from "@nostr-dev-kit/ndk-wallet";
 import { useCurrentUser } from "./useCurrentUser";
 
@@ -17,6 +18,19 @@ export function useNutsack() {
   const walletRef = useRef<NDKCashuWallet>();
   const { user } = useCurrentUser();
 
+  const getPrivateKey = useCallback((signer: any): string | undefined => {
+    const sk = signer?.privateKey ?? signer?.secretKey;
+    if (sk) return sk;
+    const nsec = signer?.nsec;
+    if (!nsec) return undefined;
+    try {
+      const data = nip19.decode(nsec).data as Uint8Array;
+      return Buffer.from(data).toString("hex");
+    } catch {
+      return undefined;
+    }
+  }, []);
+
   /**
    * Request an invoice from the wallet for the given amount. The returned
    * invoice string can be rendered as a QR code by the caller. For simplicity
@@ -24,10 +38,15 @@ export function useNutsack() {
    */
   const init = useCallback(async () => {
     if (!ndkRef.current) {
+      const sk = user ? getPrivateKey(user.signer) : undefined;
       ndkRef.current = new NDK({
         explicitRelayUrls: ["wss://relay.damus.io", "wss://relay.primal.net"],
+        signer: sk ? new NDKPrivateKeySigner(sk) : undefined,
       });
       await ndkRef.current.connect();
+    } else if (user && !ndkRef.current.signer) {
+      const sk = getPrivateKey(user.signer);
+      if (sk) ndkRef.current.signer = new NDKPrivateKeySigner(sk);
     }
     if (!walletRef.current) {
       walletRef.current = new NDKCashuWallet(ndkRef.current);
@@ -40,7 +59,7 @@ export function useNutsack() {
         setBalance(amt);
       });
     }
-  }, [setBalance]);
+  }, [setBalance, user]);
 
   useEffect(() => {
     if (user) {


### PR DESCRIPTION
## Summary
- use `NDKPrivateKeySigner` instead of the NIP‑07 signer
- add helper to extract the user's private key

## Testing
- `npm test` *(fails: unable to download packages)*

------
https://chatgpt.com/codex/tasks/task_e_6864430ae56c8326b11a0e737e93cc69