### PR TITLE
Fix wallet signer check and add wallet creation

### DIFF
--- a/src/components/Wallet.tsx
+++ b/src/components/Wallet.tsx
@@ -10,7 +10,8 @@ import { QRCodeSVG } from "qrcode.react";
 import { useCurrentUser } from "~/hooks/useCurrentUser";
 
 export function Wallet() {
-  const { balance, invoice, deposit, zap } = useNutsack();
+  const { balance, invoice, deposit, zap, createWallet, walletReady } =
+    useNutsack();
   const isAdmin = useIsAdmin();
   const { data } = useUserWallet();
   const sendZap = useSendNutzap();
@@ -47,10 +48,14 @@ export function Wallet() {
           Tokens: {data.tokens.length}
         </div>
       )}
-      <div className="flex gap-2">
-        <Button onClick={handleDeposit}>Deposit 10</Button>
-        {!isAdmin && <Button onClick={handleZap}>Zap Admin</Button>}
-      </div>
+      {!walletReady ? (
+        <Button onClick={createWallet}>Create Wallet</Button>
+      ) : (
+        <div className="flex gap-2">
+          <Button onClick={handleDeposit}>Deposit 10</Button>
+          {!isAdmin && <Button onClick={handleZap}>Zap Admin</Button>}
+        </div>
+      )}
       {depositing && <div className="text-xs">Generating invoice…</div>}
       {invoice && (
         <div className="mt-2">


### PR DESCRIPTION
## Summary
- ensure the NDK instance always has a signer
- expose wallet creation and status from `useNutsack`
- support creating a wallet in the wallet dialog before deposit/zap actions

## Testing
- `npm run test` *(fails: network access required)*

------
https://chatgpt.com/codex/tasks/task_e_686450e4eb50832694be3a207d2d9298