### PR TITLE
Add useNdk hook

### DIFF
--- a/src/hooks/useNdk.test.ts
+++ b/src/hooks/useNdk.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect, vi } from 'vitest';
+import { renderHook } from '@testing-library/react';
+import { useNdk } from './useNdk';
+
+vi.mock('@nostrify/react/login', () => ({
+  useNostrLogin: () => ({ logins: [{ id: '1', type: 'nsec', nsec: 'nsec_test' }] }),
+}));
+
+vi.mock('@nostr-dev-kit/ndk', () => ({
+  default: class { public signer: unknown; connect = vi.fn(); },
+  NDKPrivateKeySigner: class { constructor(public sk: string) {} },
+}));
+
+describe('useNdk', () => {
+  it('returns nsec from login', () => {
+    const { result } = renderHook(() => useNdk());
+    expect(result.current.nsec).toBe('nsec_test');
+    expect(result.current.ndk).toBeDefined();
+  });
+});

--- a/src/hooks/useNdk.ts
+++ b/src/hooks/useNdk.ts
@@ -1,0 +1,34 @@
+import { useEffect, useMemo, useRef } from 'react';
+import { useNostrLogin } from '@nostrify/react/login';
+import NDK, { NDKPrivateKeySigner } from '@nostr-dev-kit/ndk';
+import { nip19 } from 'nostr-tools';
+
+/**
+ * Returns the user's nsec (if available) and a configured NDK instance.
+ */
+export function useNdk() {
+  const { logins } = useNostrLogin();
+  const ndkRef = useRef<NDK>();
+
+  const nsec = useMemo(() => {
+    const login = logins.find((l) => l.type === 'nsec') as { nsec: string } | undefined;
+    return login?.nsec;
+  }, [logins]);
+
+  useEffect(() => {
+    if (!ndkRef.current) {
+      ndkRef.current = new NDK();
+    }
+
+    if (ndkRef.current && nsec) {
+      try {
+        const sk = Buffer.from(nip19.decode(nsec).data as Uint8Array).toString('hex');
+        ndkRef.current.signer = new NDKPrivateKeySigner(sk);
+      } catch (err) {
+        console.warn('Failed to set signer from nsec:', err);
+      }
+    }
+  }, [nsec]);
+
+  return { ndk: ndkRef.current, nsec } as const;
+}


### PR DESCRIPTION
## Summary
- add `useNdk` React hook for accessing a user's nsec and NDK instance
- test hook logic

## Testing
- `npm test` *(fails: 403 Forbidden – registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_68682dda6cd48326a44d0e8f6bb8cd2d